### PR TITLE
daemon: make sure the unlock loop is actually closed

### DIFF
--- a/locksmithctl/send_need_reboot.go
+++ b/locksmithctl/send_need_reboot.go
@@ -11,11 +11,11 @@ import (
 
 var (
 	cmdSendNeedReboot = &Command{
-		Name:        "send-need-reboot",
-		Summary:     "send a 'need reboot' signal over dbus.",
+		Name:    "send-need-reboot",
+		Summary: "send a 'need reboot' signal over dbus.",
 		Description: `Send a fake 'need reboot' signal to test locksmithd
 without a full update cycle via update engine.`,
-		Run:         runSendNeedReboot,
+		Run: runSendNeedReboot,
 	}
 )
 


### PR DESCRIPTION
There is a very small race that needs to be closed by ensuring the unlock loop fully exits before entering the lock loop. Needs a waitgroup or done channel.
