### PR TITLE
fix(daemon): implement exponential backoff correctly

### DIFF
--- a/locksmithctl/daemon_test.go
+++ b/locksmithctl/daemon_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestExpBackoff(t *testing.T) {
+	interval := initialInterval
+	for i := 0; i < math.MaxUint16; i++ {
+		interval = expBackoff(interval)
+		if interval < 0 {
+			t.Fatalf("interval too small: %v %v", interval, i)
+		}
+		if interval > maxInterval {
+			t.Fatal("interval too large: %v %v", interval, i)
+		}
+	}
+}


### PR DESCRIPTION
The exponential backoff code before this was prone to overflow. Instead of
relying on a "try" just increment the interval directly.

This fixes the problem where locksmithd will eat-up a ton of CPU and hit an
infinite loop. I will also cgroup locksmith next.
