### PR TITLE
feat(systemd): add some cgroup limits

### DIFF
--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -6,6 +6,9 @@ ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 
 [Service]
+CPUShares=16
+MemoryLimit=32Mb
+PrivateDevices=true
 EnvironmentFile=-/usr/share/coreos/update.conf
 EnvironmentFile=-/etc/coreos/update.conf
 ExecStart=/usr/lib/locksmith/locksmithd


### PR DESCRIPTION
Limit locksmith to some really small amount of CPU shares and a small amount
of memory.

/cc @marineam
