### PR TITLE
Warn to use `sudo` on `locksmithctl reboot`

### DIFF
--- a/locksmithctl/reboot.go
+++ b/locksmithctl/reboot.go
@@ -19,6 +19,11 @@ var (
 )
 
 func runReboot(args []string) int {
+	if os.Geteuid() != 0 {
+		fmt.Fprintln(os.Stderr, "Must be root to initiate reboot.")
+		return 1
+	}
+
 	elc, _ := lock.NewEtcdLockClient(nil)
 	lgn, err := login1.New()
 	if err != nil {


### PR DESCRIPTION
`locksmithctl reboot` takes the lock but doesn't reboot unless you run `sudo locksmithctl reboot` instead.

We need to detect and warn/mitigate against this behavior.
