### PR TITLE
updateengine: fix receiving more than one status update

### DIFF
--- a/updateengine/client.go
+++ b/updateengine/client.go
@@ -62,14 +62,16 @@ func New() (c *Client, err error) {
 }
 
 func (c *Client) RebootNeededSignal(rcvr chan Status, stop chan struct{}) {
-	select {
-	case <-stop:
-		return
-	case signal := <-c.ch:
-		s := NewStatus(signal.Body)
-		println(s.String())
-		if s.CurrentOperation == UpdateStatusUpdatedNeedReboot {
-			rcvr <- s
+	for {
+		select {
+		case <-stop:
+			return
+		case signal := <-c.ch:
+			s := NewStatus(signal.Body)
+			println(s.String())
+			if s.CurrentOperation == UpdateStatusUpdatedNeedReboot {
+				rcvr <- s
+			}
 		}
 	}
 }


### PR DESCRIPTION
Commit a2cdc597 changed a for loop into a select without providing any
other mechanism receiving multiple signals. Re-add the for. :(
