### PR TITLE
daemon: avoid double close

### DIFF
--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -223,7 +223,6 @@ func runDaemon(args []string) int {
 	go func() {
 		<-shutdown
 		fmt.Fprintln(os.Stderr, "Received interrupt/termination signal - shutting down.")
-		close(stop)
 		os.Exit(0)
 	}()
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
Fixes #29. I tested by starting then SIGTERMing and I didn't see a crash 
without this.
