### PR TITLE
Stop leaking dbus.Conn in etcdActive

### DIFF
--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -94,6 +94,7 @@ func etcdActive() (running bool, err error) {
 	if err != nil {
 		return false, err
 	}
+	defer sys.Close()
 
 	prop, err := sys.GetUnitProperty("etcd.service", "ActiveState")
 	if err != nil {

--- a/third_party/github.com/coreos/go-systemd/dbus/dbus.go
+++ b/third_party/github.com/coreos/go-systemd/dbus/dbus.go
@@ -68,6 +68,10 @@ func New() (*Conn, error) {
 	return c, nil
 }
 
+func (c *Conn) Close() {
+	c.sysconn.Close()
+}
+
 func (c *Conn) initConnection() error {
 	var err error
 	c.sysconn, err = dbus.SystemBusPrivate()


### PR DESCRIPTION
- Add Close method to sd-dbus
- Invoke Close from etcdActive
- Fix double-close bug in godbus exposed by testing above changes
