### PR TITLE
Broadcast a notice to all utmp-registered lines prior to rebooting

### DIFF
--- a/build
+++ b/build
@@ -10,4 +10,4 @@ export GOPATH=${PWD}/gopath
 
 eval $(go env)
 
-go install github.com/coreos/locksmith/locksmithctl
+go install -ldflags "$GOLDFLAGS" github.com/coreos/locksmith/locksmithctl


### PR DESCRIPTION
If any lines were found and successfully opened, the reboot is delayed
by 5 minutes.
