### PR TITLE
lock: fix etcd error handling

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -1,27 +1,13 @@
 package etcd
 
-import (
-	"fmt"
+import "github.com/coreos/locksmith/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
 
-	"github.com/coreos/locksmith/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
-)
-
-// EtcdClient is a simple wrapper around the go-etcd client to facilitate testing
+// EtcdClient is a simple wrapper around the underlying etcd client to facilitate
+// testing and minimize the interface between locksmith and the actual etcd client
 type EtcdClient interface {
 	Create(key string, value string, ttl uint64) (*etcd.Response, error)
 	CompareAndSwap(key string, value string, ttl uint64, prevValue string, prevIndex uint64) (*etcd.Response, error)
 	Get(key string, sort, recursive bool) (*etcd.Response, error)
-}
-
-type Error struct {
-	ErrorCode int    `json:"errorCode"`
-	Message   string `json:"message"`
-	Cause     string `json:"cause"`
-	Index     uint64 `json:"index"`
-}
-
-func (e Error) Error() string {
-	return fmt.Sprintf("%v: %v (%v) [%v]", e.ErrorCode, e.Message, e.Cause, e.Index)
 }
 
 type TLSInfo struct {

--- a/lock/etcd.go
+++ b/lock/etcd.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 
+	// TODO(jonboulle): this is a leaky abstraction, but we don't want to reimplement all go-etcd types in locksmith/etcd. This should go away once go-etcd is replaced.
+	goetcd "github.com/coreos/locksmith/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
 	"github.com/coreos/locksmith/etcd"
 )
 
@@ -36,7 +38,7 @@ func (c *EtcdLockClient) Init() (err error) {
 
 	_, err = c.client.Create(SemaphorePrefix, string(b), 0)
 	if err != nil {
-		eerr, ok := err.(*etcd.Error)
+		eerr, ok := err.(*goetcd.EtcdError)
 		if ok && eerr.ErrorCode == etcd.ErrorNodeExist {
 			return nil
 		}

--- a/lock/etcd_test.go
+++ b/lock/etcd_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	// TODO(jonboulle): this is a leaky abstraction, but we don't want to reimplement all go-etcd types in locksmith/etcd. This should go away once go-etcd is replaced.
 	goetcd "github.com/coreos/locksmith/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
 	"github.com/coreos/locksmith/etcd"
 )
@@ -32,8 +33,8 @@ func TestEtcdLockClientInit(t *testing.T) {
 		want bool
 	}{
 		{nil, false},
-		{&etcd.Error{ErrorCode: etcd.ErrorNodeExist}, false},
-		{&etcd.Error{ErrorCode: etcd.ErrorKeyNotFound}, true},
+		{&goetcd.EtcdError{ErrorCode: etcd.ErrorNodeExist}, false},
+		{&goetcd.EtcdError{ErrorCode: etcd.ErrorKeyNotFound}, true},
 		{errors.New("some random error"), true},
 	} {
 		elc := &EtcdLockClient{
@@ -64,7 +65,7 @@ func TestEtcdLockClientGet(t *testing.T) {
 	}{
 		// errors returned from etcd
 		{errors.New("some error"), nil, nil, true},
-		{&etcd.Error{ErrorCode: etcd.ErrorKeyNotFound}, nil, nil, true},
+		{&goetcd.EtcdError{ErrorCode: etcd.ErrorKeyNotFound}, nil, nil, true},
 		// bad JSON should cause errors
 		{nil, makeResponse(0, "asdf"), nil, true},
 		{nil, makeResponse(0, `{"semaphore:`), nil, true},
@@ -108,8 +109,8 @@ func TestEtcdLockClientSet(t *testing.T) {
 		{&Semaphore{}, nil, false},
 		{&Semaphore{Index: uint64(1234)}, nil, false},
 		// all errors returned from etcd should propagate
-		{&Semaphore{}, &etcd.Error{ErrorCode: etcd.ErrorNodeExist}, true},
-		{&Semaphore{}, &etcd.Error{ErrorCode: etcd.ErrorKeyNotFound}, true},
+		{&Semaphore{}, &goetcd.EtcdError{ErrorCode: etcd.ErrorNodeExist}, true},
+		{&Semaphore{}, &goetcd.EtcdError{ErrorCode: etcd.ErrorKeyNotFound}, true},
 		{&Semaphore{}, errors.New("some random error"), true},
 	} {
 		elc := &EtcdLockClient{


### PR DESCRIPTION
The type conversion with the new locksmith/etcd.Error introduced in 
a621605a94055a2e8ef3ebcdde85b277fd564adf unfortunately does not work, since
the underlying type is still from the go-etcd library in this case. Ideally
go-etcd should not be exposed anywhere except locksmith/etcd so I went down a
path of wrapping every go-etcd call and converting go-etcd.EtcdError to
etcd.Error, but this turned into a rabbit hole (since it implies that
go-etcd.Response should also be converted, which necessitates
locksmith/etcd.Response, ...)

For now, revert to just leaking the go-etcd types into the lock package. To be
revisited....

/cc @barakmich
