### PR TITLE
locksmith: bump to 0.2.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 const (
-	Version = "0.2.1"
+	Version = "0.2.1+git"
 )


### PR DESCRIPTION
Only change is the addition of a `-version` flag
