### PR TITLE
[#73607174] locksmithctl: Support for multiple endpoints

### DIFF
--- a/locksmithctl/locksmithctl.go
+++ b/locksmithctl/locksmithctl.go
@@ -39,7 +39,7 @@ var (
 	out *tabwriter.Writer
 
 	commands      []*Command
-	globalFlagset *flag.FlagSet = flag.NewFlagSet("locksmithctl", flag.ExitOnError)
+	globalFlagSet *flag.FlagSet = flag.NewFlagSet("locksmithctl", flag.ExitOnError)
 
 	globalFlags = struct {
 		Debug        bool
@@ -73,12 +73,12 @@ func init() {
 	out = new(tabwriter.Writer)
 	out.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
-	globalFlagset.BoolVar(&globalFlags.Debug, "debug", false, "Print out debug information to stderr.")
-	globalFlagset.Var(&globalFlags.Endpoints, "endpoint", "etcd endpoint for locksmith. Specify multiple times to use multiple endpoints.")
-	globalFlagset.StringVar(&globalFlags.EtcdKeyFile, "etcd-keyfile", "", "etcd key file authentication")
-	globalFlagset.StringVar(&globalFlags.EtcdCertFile, "etcd-certfile", "", "etcd cert file authentication")
-	globalFlagset.StringVar(&globalFlags.EtcdCAFile, "etcd-cafile", "", "etcd CA file authentication")
-	globalFlagset.BoolVar(&globalFlags.Version, "version", false, "Print the version and exit.")
+	globalFlagSet.BoolVar(&globalFlags.Debug, "debug", false, "Print out debug information to stderr.")
+	globalFlagSet.Var(&globalFlags.Endpoints, "endpoint", "etcd endpoint for locksmith. Specify multiple times to use multiple endpoints.")
+	globalFlagSet.StringVar(&globalFlags.EtcdKeyFile, "etcd-keyfile", "", "etcd key file authentication")
+	globalFlagSet.StringVar(&globalFlags.EtcdCertFile, "etcd-certfile", "", "etcd cert file authentication")
+	globalFlagSet.StringVar(&globalFlags.EtcdCAFile, "etcd-cafile", "", "etcd CA file authentication")
+	globalFlagSet.BoolVar(&globalFlags.Version, "version", false, "Print the version and exit.")
 
 	commands = []*Command{
 		cmdHelp,
@@ -101,20 +101,20 @@ type Command struct {
 }
 
 func getAllFlags() (flags []*flag.Flag) {
-	return getFlags(globalFlagset)
+	return getFlags(globalFlagSet)
 }
 
-func getFlags(flagset *flag.FlagSet) (flags []*flag.Flag) {
+func getFlags(flagSet *flag.FlagSet) (flags []*flag.Flag) {
 	flags = make([]*flag.Flag, 0)
-	flagset.VisitAll(func(f *flag.Flag) {
+	flagSet.VisitAll(func(f *flag.Flag) {
 		flags = append(flags, f)
 	})
 	return
 }
 
 func main() {
-	globalFlagset.Parse(os.Args[1:])
-	var args = globalFlagset.Args()
+	globalFlagSet.Parse(os.Args[1:])
+	var args = globalFlagSet.Args()
 
 	if len(globalFlags.Endpoints) == 0 {
 		globalFlags.Endpoints = []string{defaultEndpoint}
@@ -128,7 +128,7 @@ func main() {
 	}
 
 	if progName == "locksmithd" {
-		flagsFromEnv("LOCKSMITHD", globalFlagset)
+		flagsFromEnv("LOCKSMITHD", globalFlagSet)
 		os.Exit(runDaemon())
 	}
 
@@ -137,7 +137,7 @@ func main() {
 		args = append(args, "help")
 	}
 
-	flagsFromEnv("LOCKSMITHCTL", globalFlagset)
+	flagsFromEnv("LOCKSMITHCTL", globalFlagSet)
 
 	var cmd *Command
 
@@ -184,7 +184,7 @@ func getClient() (*lock.EtcdLockClient, error) {
 	return lc, err
 }
 
-// flagsFromEnv parses all registered flags in the given flagset,
+// flagsFromEnv parses all registered flags in the given flagSet,
 // and if they are not already set it attempts to set their values from
 // environment variables. Environment variables take the name of the flag but
 // are UPPERCASE, have the given prefix, and any dashes are replaced by


### PR DESCRIPTION
Support multiple etcd endpoints to be specified either using commandline
flags or an environment variable.

Maintains the `-endpoint` flag for backwards compatibility. Using
commandline flags, specify `-endpoint=<url>` for each endpoint or
pass a comma-delimited list of endpoints, e.g. `-endpoint=<url>,<url>`.
The former syntax is preferable IMO as it makes more sense semantically
given that `-endpoint` is singular rather than plural.

Specifying multiple endpoints using an environment variable is supported
by passing a comma-delimited list, e.g.
`LOCKSMITHCTL_ENDPOINT=<url>,<url>`.

The default endpoint of `http://127.0.0.1:4001` is retained and prints
correctly when `globalFlagset.Usage()` is called. I used `VisitAll()` to
set the default value so that I could make this distinct to the actual
flag value, which `flag.FlagSet.Var()` doesn't support.

The pattern of using a custom flag type that satisfies the `flag.Value`
interface is borrowed from example 3 of the Go Flag tests:
https://golang.org/src/flag/example_test.go

Fixes #53

* * *

Also, rename `globalFlagset` to `globalFlagSet` for consistency with the
`flag.FlagSet` struct in the Go Flag package:
http://golang.org/pkg/flag/#FlagSet