### PR TITLE
locksmithd: be more verbose when unlocking locks fails

### DIFF
--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -270,7 +270,7 @@ func unlockHeldLocks(stop chan struct{}, wg *sync.WaitGroup) {
 
 			lck, err := setupLock()
 			if err != nil {
-				reason = "error setting up lock"
+				reason = "error setting up lock: " + err.Error()
 				break
 			}
 


### PR DESCRIPTION
unlocking old locks can fail if locksmithd can't talk to etcd. print the
actual error from etcd so it can be debugged.

fixes #81 