### PR TITLE
locksmithctl: check for remote etcd cluster when unlocking.

### DIFF
--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -265,8 +265,11 @@ func unlockHeldLocks(stop chan struct{}, wg *sync.WaitGroup) {
 				break
 			}
 			if !active {
-				reason = fmt.Sprintf("%v are inactive", etcdServices)
-				break
+				_, err := getClient()
+				if err != nil {
+					reason = fmt.Sprintf("%v are inactive and remote cluster not available", etcdServices)
+					break
+				}
 			}
 
 			lck, err := setupLock()


### PR DESCRIPTION
Fixes #69 

This seems to be the least intrusive fix. A cleaner fix might be to replace all logic from `etcdActive()` to use `getClient()`; though it seems like that was proposed before in PR https://github.com/coreos/locksmith/pull/73, but not merged.