### PR TITLE
systemd: remove ordering on update-engine

### DIFF
--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Cluster reboot manager
-Requires=update-engine.service
-After=update-engine.service
 ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 


### PR DESCRIPTION
If update-engine.service has failed, locksmithd.service will fail with:

 Job locksmithd.service/start failed with result 'dependency'.

As a result, it will not retry to start itself. We can just remove this
ordering and let locksmith wait for update engine.