### PR TITLE
daemon: add LOCKSMITHD_REBOOT_DELAY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ function.
 
 [time.ParseDuration]: http://godoc.org/time#ParseDuration
 
+
+## Reboot delay
+Some systems might want to perform actinos before a reboot occurs. These systems can watch the [semaphore](#semaphore) in `etcd` for changes to the `holders` and then do any tasks (e.g. pulling machines out of worker pools, load-balancers) necessary. Using `LOCKSMITHD_REBOOT_DELAY` environment variable grants the system time to perform these actions before the  machine reboots.
+
+Usage:
+```
+LOCKSMITHD_REBOOT_DELAY=300
+```
+
+This would cause the machine to wait 300 seconds (5 minutes) after getting the lock befor rebooting.
+
+
 ## Implementation details 
 
 The following section describes how locksmith works under the hood.

--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -107,7 +107,14 @@ func rebootAndSleep(lgn *login1.Conn) {
 	if 0 != lines {
 		dlog.Noticef("Logins detected, delaying reboot for %d minutes.", delaymins)
 		time.Sleep(loginsRebootDelay)
+	} else {
+		//Don't override delay when logins are found
+		rebootDelayEnv := os.Getenv("LOCKSMITHD_REBOOT_DELAY")
+		if specifiedRebootDelaySecs, ok := rebootDelayEnv.(int); ok {
+			time.Sleep(specifiedRebootDelaySecs * time.Second)
+		}
 	}
+
 	lgn.Reboot(false)
 	dlog.Info("Reboot sent. Going to sleep.")
 


### PR DESCRIPTION
Enables applications to perform actions during the delay between the `MachineID` appearing in the semaphore `holders` field and the actual reboot. Use-cases include: updating of proxy servers, external notifications.