### PR TITLE
systemd: fix deadlock when started from cloudinit

### DIFF
--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Cluster reboot manager
-Requires=update-engine.service
-After=update-engine.service user-config.target system-config.target
 ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 


### PR DESCRIPTION
Broken by ebbef92a6. There is a loop where coreos-cloudinit waits for
locksmith to start, which depends on user-config.target, which depends
on coreos-cloudinit.