### PR TITLE
systemd: set Restart=on-failure

### DIFF
--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -11,7 +11,7 @@ Environment=GOMAXPROCS=1
 EnvironmentFile=-/usr/share/coreos/update.conf
 EnvironmentFile=-/etc/coreos/update.conf
 ExecStart=/usr/lib/locksmith/locksmithd
-Restart=always
+Restart=on-failure
 RestartSec=10s
 
 [Install]


### PR DESCRIPTION
locksmithd exits with a 0 status when the reboot strategy is off, but it
will constantly restart due to Restart=always. just restart on failures
instead.