### PR TITLE
locksmithctl: support etcd-member.service

### DIFF
--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -47,6 +47,7 @@ var (
 	etcdServices = []string{
 		"etcd.service",
 		"etcd2.service",
+		"etcd-member.service",
 	}
 
 	// TODO(mischief): daemon is not really a seperate package. it probably should be.


### PR DESCRIPTION
Add etcd-member.service to the list of services that best-effort will check to
figure out if the user has etcd running.