### PR TITLE
Build locksmithctl as a static binary

### DIFF
--- a/build
+++ b/build
@@ -11,4 +11,4 @@ export GO15VENDOREXPERIMENT=1
 
 eval $(go env)
 
-go install -ldflags "$GOLDFLAGS" github.com/coreos/locksmith/locksmithctl
+go install -ldflags "$GOLDFLAGS -extldflags -static" github.com/coreos/locksmith/locksmithctl


### PR DESCRIPTION
We use `locksmithctl` on a simple scratch image as part of a health check-driven cluster lock for Cassandra that we use to keep nodes from rebooting when Cassandra is in a bad state.

I had to build `locksmithctl` as a static binary to make this work.  Can we make this the default?  The disk usage is nominal and it's much more handy.