### PR TITLE
golang: drop support for go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: go
 matrix:
   include:
-    - go: 1.5.4
-    - go: 1.6.3
-    - go: 1.7
+    - go: 1.6.x
+    - go: 1.7.x
+    - go: 1.8.x
   allow_failures:
     - go: tip
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ else
 	Q = @
 endif
 
-export GO15VENDOREXPERIMENT:=1
-
 VERSION=$(shell git describe --dirty)
 REPO=github.com/coreos/locksmith
 LD_FLAGS="-w -s -extldflags -static"


### PR DESCRIPTION
Removed go from the travis ci language matrix, and removed the `GO15VENDOREXPERIMENT` environment variable. 