### PR TITLE
Add etcd-member.service to list of possible etcd services

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ REBOOT_STRATEGY=reboot
 The reboot strategy can also be configured through a [Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md).
 
 The default strategy is to follow the `etcd-lock` strategy if etcd is running,
-and to otherwise follow the `reboot` strategy.
+and to otherwise follow the `reboot` strategy. `locksmithd` checks if etcd is
+running by checking if some known systemd units are active, to configure an
+specific systemd unit, `LOCKSMITHD_ETCD_SERVICE` can be used.
 
 ## Usage
 

--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -50,6 +50,7 @@ var (
 	etcdServices = []string{
 		"etcd.service",
 		"etcd2.service",
+		"etcd-member.service",
 	}
 
 	// TODO(mischief): daemon is not really a seperate package. it probably should be.

--- a/locksmithctl/daemon.go
+++ b/locksmithctl/daemon.go
@@ -366,6 +366,11 @@ func runDaemon() int {
 		lengthw = os.Getenv("REBOOT_WINDOW_LENGTH")
 	}
 
+	etcdService := os.Getenv("LOCKSMITHD_ETCD_SERVICE")
+	if etcdService != "" {
+		etcdServices = []string{etcdService}
+	}
+
 	if (startw == "") != (lengthw == "") {
 		dlog.Fatal("Either both or neither $REBOOT_WINDOW_START and $REBOOT_WINDOW_LENGTH must be set")
 	}


### PR DESCRIPTION
In latest versions of CoreOS `etcd-member.service` can be used to start any containerized version of etcd, this should be added to the list of possible etcd services.

Additionaly, `LOCKSMITHD_ETCD_SERVICE` can be used now to declare an specific systemd unit to check.