### PR TITLE
systemd: run After update_engine

### DIFF
--- a/systemd/locksmithd.service
+++ b/systemd/locksmithd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Cluster reboot manager
+After=update-engine.service
 ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 


### PR DESCRIPTION
d01a4c35547df8affb025840f02caa3ab209e9be dropped a `Requires`/`After` on update-engine.service, since those would prevent systemd from restarting locksmithd if update-engine failed. However, that change created a race in which locksmithd would start before update_engine, fail with

    Cannot get update engine status: The name com.coreos.update1 was not provided by any .service files

and be restarted by systemd 10 seconds later.

Ideally update_engine would support bus activation, but enabling that would require users to take an additional step when disabling update_engine, breaking backward compatibility. Instead, add an After
to fix the race, but do not pull in update_engine. In principle we could also add a `Wants`, but that would change behavior in a corner case (restarting locksmithd with update_engine stopped).