### PR TITLE
 locksmithd: ignore nil sent by dbus.Signal 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 matrix:
   include:
     - go: 1.6.x
-    - go: 1.7.x
-    - go: 1.8.x
+    - go: 1.9.x
+    - go: 1.10.x
   allow_failures:
     - go: tip
 
@@ -12,4 +12,3 @@ install: true
 
 script:
  - make test
-

--- a/updateengine/client.go
+++ b/updateengine/client.go
@@ -89,7 +89,10 @@ func (c *Client) RebootNeededSignal(rcvr chan Status, stop chan struct{}) {
 		case <-stop:
 			return
 		case signal := <-c.ch:
-			s := NewStatus(signal.Body)
+			s, err := TryNewStatus(signal)
+			if err != nil {
+				continue
+			}
 			println(s.String())
 			if s.CurrentOperation == UpdateStatusUpdatedNeedReboot {
 				rcvr <- s

--- a/updateengine/client_test.go
+++ b/updateengine/client_test.go
@@ -93,6 +93,20 @@ func TestRebootNeededSignal(t *testing.T) {
 		t.Fatal("RebootNeededSignal stopped prematurely")
 	}
 
+	c.ch <- nil
+
+	time.Sleep(10 * time.Millisecond)
+
+	select {
+	case stat := <-r:
+		t.Fatalf("unexpected status on nil signal: %#v", stat)
+	default:
+	}
+
+	if done {
+		t.Fatal("RebootNeededSignal stopped prematurely")
+	}
+
 	close(s)
 
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
Specifies the loop in RebootNeededSignal to continue if a 'nil' signal is
sent to the client channel connected to the D-Bus. This avoids
dereferencing a nil datatype in NewStatus, which causes the panic in
coreos/bugs#1987.

fixes coreos/bugs#1987